### PR TITLE
Remove usage of ConvertFrom-Json

### DIFF
--- a/exercises/scripts/0-prerequisites.ps1
+++ b/exercises/scripts/0-prerequisites.ps1
@@ -43,7 +43,7 @@ $StorageAccountNames = @($env:ASNFD_STORAGE_ACCOUNT_NAME_EU, $env:ASNFD_STORAGE_
 $AppServicePlanNames = @($env:ASNFD_APP_SERVICE_PLAN_NAME_EU, $env:ASNFD_APP_SERVICE_PLAN_NAME_US)
 $AppServiceNames = @($env:ASNFD_APP_SERVICE_NAME_EU, $env:ASNFD_APP_SERVICE_NAME_US)
 
-$AzureSubscriptionId = (az account show | ConvertFrom-Json).id
+$AzureSubscriptionId = (az account show --query id --output tsv)
 
 Write-Output "`nAzure subscription ID: ${AzureSubscriptionId}"
 
@@ -113,7 +113,7 @@ for ($i = 0; $i -lt 2; $i++) {
     Write-Output "`nAssigning identity for app service `"${AppServiceName}`" (resource group `"${ResourceGroupName}`")..."
     # https://learn.microsoft.com/cli/azure/webapp/identity?view=azure-cli-latest#az-webapp-identity-assign()
 
-    $AppServicePrincipalId = (az webapp identity assign --resource-group $ResourceGroupName --name $AppServiceName | ConvertFrom-Json).principalId
+    $AppServicePrincipalId = (az webapp identity assign --resource-group $ResourceGroupName --name $AppServiceName --query principalId --output tsv)
     Write-Output "Principal ID of app service ${AppServiceName}: ${AppServicePrincipalId}"
 
     Write-Output "`nPausing the script to give time for the previous operation(s) to take an effect, please wait..."

--- a/exercises/scripts/subscripts/2-3-1-storage-account-enable-access-from-vnet.ps1
+++ b/exercises/scripts/subscripts/2-3-1-storage-account-enable-access-from-vnet.ps1
@@ -31,7 +31,7 @@ az storage account update `
     --default-action Deny
 
 Write-Output "`n3/3 Adding network rule to storage account ${StorageAccountName} to allow access via subnet ${SubnetName}..."
-$SubnetResourceId = (az network vnet subnet show --resource-group $ResourceGroupName --vnet-name $VnetName --name $SubnetName | ConvertFrom-Json).id
+$SubnetResourceId = (az network vnet subnet show --resource-group $ResourceGroupName --vnet-name $VnetName --name $SubnetName --query id --output tsv)
 
 # https://learn.microsoft.com/cli/azure/storage/account/network-rule?view=azure-cli-latest()
 

--- a/exercises/scripts/subscripts/2-3-private-endpoints.ps1
+++ b/exercises/scripts/subscripts/2-3-private-endpoints.ps1
@@ -22,16 +22,11 @@ $StorageAccountNameEu = $env:ASNFD_STORAGE_ACCOUNT_NAME_EU
 $StorageAccountNameUs = $env:ASNFD_STORAGE_ACCOUNT_NAME_US
 $StorageAccountNameHub = $env:ASNFD_STORAGE_ACCOUNT_NAME_HUB
 
-$AppServiceInformationEu = (az webapp list --resource-group $ResourceGroupNameEu --query "[?name=='${AppServiceNameEu}']" | ConvertFrom-Json)
-$AppServiceResourceIdEu = $AppServiceInformationEu.id
-$AppServiceInformationUs = (az webapp list --resource-group $ResourceGroupNameUs --query "[?name=='${AppServiceNameUs}']" | ConvertFrom-Json)
-$AppServiceResourceIdUs = $AppServiceInformationUs.id
-$StorageAccountInformationEu = (az storage account list --resource-group $ResourceGroupNameEu --query "[?name=='${StorageAccountNameEu}']" | ConvertFrom-Json)
-$StorageAccountResourceIdEu = $StorageAccountInformationEu.id
-$StorageAccountInformationUs = (az storage account list --resource-group $ResourceGroupNameUs --query "[?name=='${StorageAccountNameUs}']" | ConvertFrom-Json)
-$StorageAccountResourceIdUs = $StorageAccountInformationUs.id
-$StorageAccountInformationHub = (az storage account list --resource-group $ResourceGroupNameHub --query "[?name=='${StorageAccountNameHub}']" | ConvertFrom-Json)
-$StorageAccountResourceIdShared = $StorageAccountInformationHub.id
+$AppServiceResourceIdEu = (az webapp list --resource-group $ResourceGroupNameEu --query "[?name=='${AppServiceNameEu}'].id"--output tsv)
+$AppServiceResourceIdUs = (az webapp list --resource-group $ResourceGroupNameUs --query "[?name=='${AppServiceNameUs}'].id" --output tsv)
+$StorageAccountResourceIdEu = (az storage account list --resource-group $ResourceGroupNameEu --query "[?name=='${StorageAccountNameEu}'].id" --output tsv)
+$StorageAccountResourceIdUs = (az storage account list --resource-group $ResourceGroupNameUs --query "[?name=='${StorageAccountNameUs}'].id" --output tsv)
+$StorageAccountResourceIdShared = (az storage account list --resource-group $ResourceGroupNameHub --query "[?name=='${StorageAccountNameHub}'].id" --output tsv)
 
 Write-Output "`nCreating private endpoint for EU app service..."
 # https://learn.microsoft.com/cli/azure/network/private-endpoint?view=azure-cli-latest#az-network-private-endpoint-create()

--- a/exercises/scripts/subscripts/3-1-vnet-peerings.ps1
+++ b/exercises/scripts/subscripts/3-1-vnet-peerings.ps1
@@ -7,8 +7,8 @@ param(
 
 Write-Output "`nPeering virtual networks ${VnetName1} <-> ${VnetName2}..."
 
-$VnetResourceId1 = (az network vnet show --resource-group $ResourceGroupName1 --name $VnetName1 | ConvertFrom-Json).id
-$VnetResourceId2 = (az network vnet show --resource-group $ResourceGroupName2 --name $VnetName2 | ConvertFrom-Json).id
+$VnetResourceId1 = (az network vnet show --resource-group $ResourceGroupName1 --name $VnetName1 --query id --output tsv)
+$VnetResourceId2 = (az network vnet show --resource-group $ResourceGroupName2 --name $VnetName2 --query id --output tsv)
 
 # https://learn.microsoft.com/cli/azure/network/vnet/peering?view=azure-cli-latest#az-network-vnet-peering-create()
 

--- a/exercises/scripts/subscripts/5-1-firewall.ps1
+++ b/exercises/scripts/subscripts/5-1-firewall.ps1
@@ -59,6 +59,6 @@ az network public-ip show `
     --resource-group $ResourceGroupName
 
 # https://learn.microsoft.com/cli/azure/network/firewall/ip-config?view=azure-cli-latest#az-network-firewall-ip-config-list
-$FirewallPrivateIpAddress=(az network firewall ip-config list --resource-group $ResourceGroupName --firewall-name $FirewallName --query "[?name=='${FirewallPublicIpConfigName}'].privateIpAddress" | ConvertFrom-Json)
+$FirewallPrivateIpAddress=(az network firewall ip-config list --resource-group $ResourceGroupName --firewall-name $FirewallName --query "[?name=='${FirewallPublicIpConfigName}'].privateIpAddress" --output tsv)
 
 Write-Output "`nFirewall private IP address: ${FirewallPrivateIpAddress}"


### PR DESCRIPTION
While this is equivalent, it uses a single command to get the necessary values.

The reason I made this fix was that the pipes to `ConvertFrom-Json` were failing on my machine with WSL2 running Ubuntu with Powershell 7.4.2. This change removes the Powershell from the equation