### PR TITLE
Documentation and script validations to catch small errors early during prerequisites steps

### DIFF
--- a/exercises/instructions/0-prerequisites.md
+++ b/exercises/instructions/0-prerequisites.md
@@ -20,6 +20,18 @@ It is recommended to use Azure Cloud Shell for the exercises, as it has all the 
     cd ./azure-secure-networking-for-devs/exercises/scripts/
     ```
 
+1. Set the subscription for your resources
+
+    ```ps1
+    az account set -s <subscription name or ID>
+    ```
+
+1. Make sure the current subscription is the expected one
+
+    ```ps1
+    az account show
+    ```
+
 1. Set environment variables defining the team name and the Azure locations (regions) to use:
 
     ```ps1

--- a/exercises/instructions/0-prerequisites.md
+++ b/exercises/instructions/0-prerequisites.md
@@ -20,13 +20,13 @@ It is recommended to use Azure Cloud Shell for the exercises, as it has all the 
     cd ./azure-secure-networking-for-devs/exercises/scripts/
     ```
 
-1. Set the subscription for your resources
+1. Set the Azure Subscription for your resources
 
     ```ps1
     az account set -s <subscription name or ID>
     ```
 
-1. Make sure the current subscription is the expected one
+1. Make sure the current Subscription is the expected one
 
     ```ps1
     az account show

--- a/exercises/scripts/set-env.ps1
+++ b/exercises/scripts/set-env.ps1
@@ -7,6 +7,21 @@ param(
     [string]$HubLocation = "swedencentral"
 )
 
+if ($TeamName.Length -lt 2) {
+    Write-Error "Invalid argument: Team name missing or too short (must be at least 2 characters long)"
+    exit 1
+}
+
+if ($TeamName.Length -gt 10) {
+    Write-Error "Invalid argument: Team name too long (must be less than 10 characters long)"
+    exit 1
+}
+
+if ($TeamName -cnotmatch '^[a-z0-9]+$') {
+    Write-Error "Invalid argument: Team name is invalid (must be lower case alphanumeric characters)"
+    exit 1
+}
+
 $env:TEAM_NAME = $TeamName
 $env:HUB_LOCATION = $HubLocation
 $env:EU_LOCATION = $EuLocation


### PR DESCRIPTION
1. Add instructions to the prerequisites for users to set and double check the current subscription. This should reduce chances of accidentally deploying to the incorrect subscription.
2. Add validation to the `TeamName` param in the `set-env.ps1` script to match the constraints detailed in the instructions. This will also catch errors early and reduce chances of users creating resources before realizing storage account names are invalid.