### PR TITLE
Update Win11 vm image due to deprecation

### DIFF
--- a/exercises/scripts/subscripts/0-2-jumpbox.ps1
+++ b/exercises/scripts/subscripts/0-2-jumpbox.ps1
@@ -17,7 +17,7 @@ $JumpboxVmName = "vm${TeamName}hub"  # Max 15 characters for Windows machines
 $JumpboxOsDiskName = "vmdisk-${TeamName}-${Environment}-hub"
 
 # To list available VMs, run command "az vm image list --offer Windows-11 --all --output table"
-$JumpboxVmImage = "MicrosoftWindowsDesktop:windows-11:win11-23h2-pro:22631.3737.240607" # URN format for '--image': "Publisher:Offer:Sku:Version"
+$JumpboxVmImage = "MicrosoftWindowsDesktop:windows-11:win11-23h2-pro:22631.4037.240811" # URN format for '--image': "Publisher:Offer:Sku:Version"
 
 Write-Output "`nCreating network security group (NSG) for jumpbox..."
 # https://learn.microsoft.com/cli/azure/network/nsg?view=azure-cli-latest#az-network-nsg-create()


### PR DESCRIPTION
I'm seeing warnings regarding the deprecation of the VM image.
![image](https://github.com/user-attachments/assets/61d8433a-b276-4e17-90c8-3ea7bf7d11e9)

4037 is not yet deprecated, so switching to that
![image](https://github.com/user-attachments/assets/a0948604-7862-4b71-a06a-fadc37c6f390)


